### PR TITLE
Fix bug where having only one or two independent columns would crash

### DIFF
--- a/Kruskals/kruskals.py
+++ b/Kruskals/kruskals.py
@@ -93,16 +93,22 @@ class Kruskals(object):
             np.cov(np.array([ndarr[:,j], arr, ndarr[:,i]]))
             for j, i in permutations(range(l), 2)
         )
+
+        if len(cov_ij) == 0:
+            return (l, np.empty((1, l-1)) * np.nan, np.empty((l,1)) * np.nan)
+
         pinv_ij = np.linalg.pinv(cov_ij, hermitian=True)
         pcor_ij = ((pinv_ij[:, 0, 1] * pinv_ij[:, 0, 1]) / (pinv_ij[:, 0, 0] * pinv_ij[:, 1, 1]))
-
-        m_ijm = np.empty((l,l,l)) * np.nan
 
         cov_mij = [
             np.cov(np.array([ndarr[:,i], arr, ndarr[:,j], ndarr[:, m]]))
             for i, j in permutations(range(l), 2)
             for m in range(j+1, l) if m != i
         ]
+
+        if len(cov_mij) == 0:
+            return (l, pcor_ij.reshape(-1, l-1), np.empty((l,1)) * np.nan)
+
         pinv_mij = np.linalg.pinv(cov_mij, hermitian=True)
         pcor_mij = ((pinv_mij[:, 0, 1] * pinv_mij[:, 0, 1]) / (pinv_mij[:, 0, 0] * pinv_mij[:, 1, 1]))
 

--- a/tests/test_kruskals.py
+++ b/tests/test_kruskals.py
@@ -228,3 +228,37 @@ def test_dependent_variable_can_be_nan():
     arr = np.array([1, 2, 3, 4, np.nan, 6, 7, 8])
     percentage = Kruskals.Kruskals(ndarr, arr).driver_score(directional=True, percentage=True)
     assert (np.round(percentage, decimals=4) == [-17.2805, -13.5913, -14.5028, 23.0658, -22.5377, 9.0218]).all()
+
+
+def test_independent_1_col():
+    ndarr = np.array([
+      [10],
+      [6],
+      [1],
+      [9],
+      [3],
+      [1],
+      [1],
+      [1],
+    ])
+    arr = np.array([1, 2, 3, 4, 5, 6, 7, 8])
+    percentage = Kruskals.Kruskals(ndarr, arr).driver_score(directional=True, percentage=True)
+
+    assert (np.isnan(np.round(percentage, decimals=4))).all()
+
+
+def test_independent_2_col():
+    ndarr = np.array([
+      [10, 2],
+      [6, 5],
+      [1, 1],
+      [9, 2],
+      [3, 3],
+      [1, 2],
+      [1, 2],
+      [1, 2]
+    ])
+    arr = np.array([1, 2, 3, 4, 5, 6, 7, 8])
+    percentage = Kruskals.Kruskals(ndarr, arr).driver_score(directional=True, percentage=True)
+
+    assert (np.isnan(np.round(percentage, decimals=4))).all()


### PR DESCRIPTION
This bug was introduced in 1.3.0.

I have checked the new unit tests against 1.2.1 and they pass there too.